### PR TITLE
FIX: Compatibility with upcoming core changes

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+2.7.0.beta5: a7424adc3912a31143080bbf0a1d2002c73beaff

--- a/javascripts/discourse/components/gif-button.js.es6
+++ b/javascripts/discourse/components/gif-button.js.es6
@@ -1,5 +1,5 @@
 import Component from "@ember/component";
-import { showGifModal } from "discourse/helpers/gif-modal";
+import { showGifModal } from "../helpers/gif-modal";
 
 export default Component.extend({
   tagName: "",

--- a/javascripts/discourse/initializers/gif-integration.js.es6
+++ b/javascripts/discourse/initializers/gif-integration.js.es6
@@ -1,6 +1,6 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import Composer from "discourse/components/d-editor";
-import { showGifModal } from "discourse/helpers/gif-modal";
+import { showGifModal } from "../helpers/gif-modal";
 
 export default {
   name: "discourse-gifs",


### PR DESCRIPTION
Should be merged after https://github.com/discourse/discourse/commit/2b9ab3a0d91d1350188dd554764dbb4ce9837edd is un-reverted.