### PR TITLE
UX: Layout improvements for the modal

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -18,13 +18,54 @@ html:not(.discourse-gifs-with-img)
 }
 
 .gif-modal {
+  .gif-input {
+    background: var(--primary-very-low);
+    padding: 0.5em;
+    position: relative;
+    > input {
+      width: 100%;
+      margin-right: 1em;
+      margin-bottom: 0;
+    }
+    .spinner {
+      position: absolute;
+      right: 1.2em;
+      top: 0.9em;
+    }
+  }
+
+  .gif-content {
+    height: calc(100% - 50px);
+    overflow-y: auto;
+    margin-top: 1em;
+  }
   .gif-box {
-    > div {
+    min-width: 320px;
+    max-height: 350px;
+
+    .gif-result-list {
+      padding-top: 1em;
       display: grid;
       grid-template-columns: repeat(4, 1fr);
-      grid-template-rows: masonry;
-      grid-gap: 10px;
-      max-height: 350px;
+      // TODO: Use this once support is more widespread
+      // grid-template-rows: masonry;
+      grid-gap: 0.6em;
+      grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+      grid-auto-rows: 20px;
+      .gif-imgwrap {
+        grid-row-end: span 3;
+        overflow: hidden;
+        background: var(--primary-very-low);
+        img {
+          max-width: 100%;
+        }
+      }
+      .tall-one {
+        grid-row-end: span 6;
+      }
+      .tall-two {
+        grid-row-end: span 4;
+      }
     }
     div[data-theme-discourse-gifs="container"],
     div[data-theme-discourse-gifs="webp-container"] {
@@ -33,6 +74,21 @@ html:not(.discourse-gifs-with-img)
     div.loading-container {
       display: block;
       height: 10px;
+    }
+
+    .gif-no-results {
+      padding-top: 1em;
+      width: 100%;
+      height: 210px;
+      box-sizing: border-box;
+      padding: 2em;
+      background: var(--primary-very-low);
+      font-size: var(--font-up-1);
+      color: var(--primary-medium);
+      font-weight: bold;
+      display: flex;
+      align-items: center;
+      text-align: center;
     }
   }
   .modal-footer {

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,0 +1,4 @@
+.gif-modal .gif-box {
+  min-width: 650px;
+  max-height: 420px;
+}

--- a/javascripts/discourse/components/gif-result.js.es6
+++ b/javascripts/discourse/components/gif-result.js.es6
@@ -1,10 +1,22 @@
+import discourseComputed from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 
 export default Component.extend({
   tagName: "div",
   classNames: ["gif-imgwrap"],
+  classNameBindings: ["tallOne", "tallTwo"],
+
+  @discourseComputed("gif.height", "gif.width")
+  tallOne(height, width) {
+    return height / width > 1.5;
+  },
+
+  @discourseComputed("gif.height", "gif.width")
+  tallTwo(height, width) {
+    return height / width > 1 && height / width < 1.5;
+  },
 
   click() {
     this.pick(this.gif);
-  }
+  },
 });

--- a/javascripts/discourse/controllers/gif.js.es6
+++ b/javascripts/discourse/controllers/gif.js.es6
@@ -52,8 +52,14 @@ export default Controller.extend(ModalFunctionality, {
         .done((response) => {
           const images = response.data.map((gif) => ({
             title: gif.title,
-            preview: settings.giphy_file_format === 'webp' ? gif.images.fixed_width_small.webp : gif.images.fixed_width_small.url,
-            original: settings.giphy_file_format === 'webp' ? gif.images.original.webp : gif.images.original.url,
+            preview:
+              settings.giphy_file_format === "webp"
+                ? gif.images.fixed_width.webp
+                : gif.images.fixed_width.url,
+            original:
+              settings.giphy_file_format === "webp"
+                ? gif.images.original.webp
+                : gif.images.original.url,
             width: gif.images.original.width,
             height: gif.images.original.height,
           }));

--- a/javascripts/discourse/templates/modal/gif.hbs
+++ b/javascripts/discourse/templates/modal/gif.hbs
@@ -1,5 +1,5 @@
 {{#d-modal-body id="gif-modal"}}
-  <div>
+  <div class="gif-input">
     {{input
       type="text"
       name="query"
@@ -7,13 +7,16 @@
       key-up=(action "refresh")
     }}
     {{#if loading}}
-      {{i18n "loading"}}
+      {{loading-spinner size="small"}}
     {{/if}}
   </div>
   <div class="gif-content">
-
     <div class="gif-box">
-      {{gif-result-list content=currentGifs pick=(action "pick") loadMore=(action "loadMore")}}
+      {{#if currentGifs}}
+        {{gif-result-list content=currentGifs pick=(action "pick") loadMore=(action "loadMore")}}
+      {{else}}
+        <div class="gif-no-results">{{theme-i18n "gif.no_results"}}</div>
+      {{/if}}
     </div>
   </div>
 {{/d-modal-body}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,7 +1,8 @@
 en:
   gif:
-    modal_title: "Search Gif"
+    modal_title: "Search GIFs"
     query: "Term"
     insert: "Insert Selected Images"
-    composer_title: "Search Gif"
+    composer_title: "Search GIFs"
     bad_api_key: "Missing or wrong Giphy API Key set. Ask the site admin to follow the install instructions at <a href='https://meta.discourse.org/t/discourse-gifs-component/158738'>https://meta.discourse.org/t/discourse-gifs-component/158738</a>."
+    no_results: "Enter a keyword in the input box above to search for GIFs."


### PR DESCRIPTION
Desktop: 

<img width="1109" alt="image" src="https://user-images.githubusercontent.com/368961/119878344-029de080-bef8-11eb-91ad-629ae0706c22.png">

Mobile: 

<img width="348" alt="image" src="https://user-images.githubusercontent.com/368961/119878429-19443780-bef8-11eb-9ccf-c3aa3b3d4bef.png">

I also updated the empty screen so that there is less jumping once there are results: 

<img width="655" alt="image" src="https://user-images.githubusercontent.com/368961/119879131-e0f12900-bef8-11eb-8355-c0116c1cb95d.png">
