### PR TITLE
FEATURE: Add giphy content rating setting

### DIFF
--- a/javascripts/discourse/controllers/gif.js.es6
+++ b/javascripts/discourse/controllers/gif.js.es6
@@ -101,6 +101,7 @@ export default Controller.extend(ModalFunctionality, {
         offset: offset,
         api_key: settings.giphy_api_key,
         lang: settings.giphy_locale,
+        rating: settings.giphy_content_rating,
       })
     );
   },

--- a/settings.yml
+++ b/settings.yml
@@ -46,3 +46,13 @@ giphy_file_format:
   choices:
     - webp
     - gif
+giphy_content_rating:
+  type: enum
+  default: r
+  description: |
+    Content rating for gif search results, more info at <a href="https://developers.giphy.com/docs/optional-settings#rating">https://developers.giphy.com/docs/optional-settings#rating</a>
+  choices:
+    - g
+    - pg
+    - pg-13
+    - r


### PR DESCRIPTION
This adds a theme setting that allows admins to filter gif results with giphy's rating system: https://developers.giphy.com/docs/optional-settings#rating