### PR TITLE
Change to new Tenor API Endpoint

### DIFF
--- a/javascripts/discourse/controllers/gif.js.es6
+++ b/javascripts/discourse/controllers/gif.js.es6
@@ -122,7 +122,7 @@ export default Controller.extend(ModalFunctionality, {
   getEndpoint(query, offset) {
     if (settings.api_provider == "tenor") {
       return (
-        "https://api.tenor.com/v1/search?" +
+        "https://g.tenor.com/v1/search?" +
         $.param({
           limit: 24,
           q: query,


### PR DESCRIPTION
> While the domain api.tenor.com will continue to be supported, g.tenor.com offers significant benefits. g.tenor.com has an additional cache layer and is located at edge nodes across the world, resulting in lower average API latencies across all regions. As such, Tenor recommends using g.tenor.com and has updated the documentation to reflect that.

See more at https://tenor.com/gifapi/documentation#endpoints-domains