### PR TITLE
FIX: Use actual Promise methods

### DIFF
--- a/javascripts/discourse/controllers/gif.js
+++ b/javascripts/discourse/controllers/gif.js
@@ -62,7 +62,7 @@ export default Controller.extend(ModalFunctionality, {
       this.set("loading", true);
 
       ajax({ url: this.getEndpoint(this.query, this.offset) })
-        .done((response) => {
+        .then((response) => {
           let images;
           if (settings.api_provider === "giphy") {
             // Giphy
@@ -104,7 +104,7 @@ export default Controller.extend(ModalFunctionality, {
             popupAjaxError(error);
           }
         })
-        .always(() => {
+        .finally(() => {
           this.set("loading", false);
         });
     }


### PR DESCRIPTION
I didn't realize it was using jQuery methods before, so my previous commit that replaced `$.ajax` with the imported version broke the component.