### PR TITLE
Added Support for Tenor V2 Google API

### DIFF
--- a/javascripts/discourse/controllers/gif.js
+++ b/javascripts/discourse/controllers/gif.js
@@ -93,7 +93,7 @@ export default Controller.extend(ModalFunctionality, {
           if (
             !errorMsg &&
             settings.api_provider === "tenor" &&
-            response.headers["content-type"].includes("application/json")
+            response.headers.get("content-type")?.includes("application/json")
           ) {
             const errorResponse = await response.json();
             switch (settings.tenor_api_version) {

--- a/javascripts/discourse/controllers/gif.js
+++ b/javascripts/discourse/controllers/gif.js
@@ -93,7 +93,7 @@ export default Controller.extend(ModalFunctionality, {
           if (
             !errorMsg &&
             settings.api_provider === "tenor" &&
-            response.headers["Content-Type"] === "application/json"
+            response.headers["content-type"].includes("application/json")
           ) {
             const errorResponse = await response.json();
             switch (settings.tenor_api_version) {
@@ -101,12 +101,12 @@ export default Controller.extend(ModalFunctionality, {
                 // Error Message should include `code` and `error`
                 if (errorResponse.code && errorResponse.error) {
                   throw new Error(
-                    `Tenor API Error ${errorResponse.code}: ${errorResponse.error}`
+                    `Tenor Status ${errorResponse.code}: ${errorResponse.error}`
                   );
                 } else {
                   // Fallback as Error Response does not match what was expected.
                   throw new Error(
-                    `Tenor API Error ${response.status}: ${JSON.stringify(
+                    `Tenor Status ${response.status}: ${JSON.stringify(
                       errorResponse
                     )}`
                   );
@@ -123,7 +123,7 @@ export default Controller.extend(ModalFunctionality, {
                 } else {
                   // Map Error Message according to default Google API standards
                   throw new Error(
-                    `Tenor API Error ${errorResponse.error.code}: ${
+                    `Tenor Error Code ${errorResponse.error.code}: ${
                       errorResponse.error.message
                     } [${errorResponse.error.details
                       .map((e) => e.reason)
@@ -158,7 +158,7 @@ export default Controller.extend(ModalFunctionality, {
           } else {
             // Fallback to returning the entire response along with a status code.
             throw new Error(
-              `API Error ${response.status}: ${await response.text()}`
+              `${settings.api_provider.toUpperCase()} Status ${response.status}: ${await response.text()}`
             );
           }
         }

--- a/javascripts/discourse/controllers/gif.js
+++ b/javascripts/discourse/controllers/gif.js
@@ -73,7 +73,8 @@ export default Controller.extend(ModalFunctionality, {
           (settings.api_provider === "giphy" && settings.giphy_api_key === "")
         ) {
           throw new Error(`${settings.api_provider.toUpperCase()} API key is not set. Site Admins, \
-            please visit <a href="https://meta.discourse.org/t/discourse-gifs/158738">Discourse Meta</a> \
+            please visit <a target="_blank" rel="noreferrer noopener" \
+            href="https://meta.discourse.org/t/discourse-gifs/158738">Discourse Meta</a> \
             for setup instructions.`);
         }
 

--- a/javascripts/discourse/controllers/gif.js
+++ b/javascripts/discourse/controllers/gif.js
@@ -70,7 +70,7 @@ export default Controller.extend(ModalFunctionality, {
         const response = await fetch(this.getEndpoint(this.query, this.offset));
 
         if (!response.ok) {
-          // Use the same errorMsg variable to handle variable replacement at the end for API Provider Display Name {{api_provider}}.
+          // Use the same errorMsg variable to handle variable replacement at the end for API Provider Display Name $api_provider.
           let errorMsg;
 
           // Only check for certain errors if setting is configured to do so.
@@ -136,7 +136,7 @@ export default Controller.extend(ModalFunctionality, {
           // If error message is set, check if the API Provider variable was used.
           // Replace if needed - throw at the end of it.
           if (errorMsg) {
-            if (errorMsg.indexOf("{{api_provider}}") > -1) {
+            if (errorMsg.indexOf("$api_provider") > -1) {
               let providerName;
               switch (settings.api_provider) {
                 case "giphy":
@@ -150,7 +150,7 @@ export default Controller.extend(ModalFunctionality, {
               }
 
               throw new Error(
-                errorMsg.replaceAll("{{api_provider}}", providerName)
+                errorMsg.replaceAll("$api_provider", providerName)
               );
             } else {
               throw new Error(errorMsg);

--- a/javascripts/discourse/controllers/gif.js
+++ b/javascripts/discourse/controllers/gif.js
@@ -70,7 +70,7 @@ export default Controller.extend(ModalFunctionality, {
         const response = await fetch(this.getEndpoint(this.query, this.offset));
 
         if (!response.ok) {
-          // Use the same errorMsg variable to handle variable replacement at the end for API Vendor Display Name {{api_vendor}}.
+          // Use the same errorMsg variable to handle variable replacement at the end for API Provider Display Name {{api_provider}}.
           let errorMsg;
 
           // Only check for certain errors if setting is configured to do so.
@@ -138,7 +138,7 @@ export default Controller.extend(ModalFunctionality, {
           if (errorMsg) {
             if (errorMsg.indexOf("{{api_provider}}") > -1) {
               let providerName;
-              switch (providerName) {
+              switch (settings.api_provider) {
                 case "giphy":
                   providerName = "GIPHY";
                   break;

--- a/javascripts/discourse/controllers/gif.js
+++ b/javascripts/discourse/controllers/gif.js
@@ -210,7 +210,7 @@ export default Controller.extend(ModalFunctionality, {
 
   getEndpoint(query, offset) {
     if (settings.api_provider === "tenor") {
-      var params = {
+      let params = {
         key: settings.tenor_api_key,
         q: query,
         country: settings.tenor_country,

--- a/javascripts/discourse/controllers/gif.js
+++ b/javascripts/discourse/controllers/gif.js
@@ -58,20 +58,21 @@ export default Controller.extend(ModalFunctionality, {
 
     // Check for minimum search query and if search result limit was set & reached
     if (
-      this.query &&
-      this.query.length > 2 &&
-      settings.allow_unlimited_search ||
-        (!settings.allow_unlimited_search &&
-          this.currentGifs.length < settings.max_results_limit)
+      (this.query &&
+        this.query.length > 2 &&
+        !settings.limit_infinite_search_results) ||
+      (settings.limit_infinite_search_results &&
+        this.currentGifs.length < settings.max_results_limit)
     ) {
       this.set("loading", true);
 
       try {
         if (
-          (settings.api_provider === "tenor" && settings.tenor_api_key === "") ||
+          (settings.api_provider === "tenor" &&
+            settings.tenor_api_key === "") ||
           (settings.api_provider === "giphy" && settings.giphy_api_key === "")
         ) {
-          throw new Error(`${settings.api_provider} API key is not set. Site Admins, \
+          throw new Error(`${settings.api_provider.toUpperCase()} API key is not set. Site Admins, \
             please visit <a href="https://meta.discourse.org/t/discourse-gifs/158738">Discourse Meta</a> \
             for setup instructions.`);
         }
@@ -121,25 +122,12 @@ export default Controller.extend(ModalFunctionality, {
           // If error message is set, check if the API Provider variable was used.
           // Replace if needed - throw at the end of it.
           if (errorMsg) {
-            if (errorMsg.indexOf("$api_provider") > -1) {
-              let providerName;
-              switch (settings.api_provider) {
-                case "giphy":
-                  providerName = "GIPHY";
-                  break;
-                case "tenor":
-                  providerName = "Tenor";
-                  break;
-                default:
-                  providerName = settings.api_provider;
-              }
-
-              throw new Error(
-                errorMsg.replaceAll("$api_provider", providerName)
-              );
-            } else {
-              throw new Error(errorMsg);
-            }
+            throw new Error(
+              errorMsg.replaceAll(
+                "$api_provider",
+                settings.api_provider.toUpperCase()
+              )
+            );
           } else {
             // Fallback to returning the entire response along with a status code.
             throw new Error(

--- a/javascripts/discourse/controllers/gif.js
+++ b/javascripts/discourse/controllers/gif.js
@@ -90,10 +90,10 @@ export default Controller.extend(ModalFunctionality, {
           // Tenor
           images = data.results.map((gif) => ({
             title: gif.title,
-            preview: gif.media[0].tinygif.url,
-            original: gif.media[0][`${settings.tenor_file_detail}`].url,
-            width: gif.media[0][`${settings.tenor_file_detail}`].dims[0],
-            height: gif.media[0][`${settings.tenor_file_detail}`].dims[1],
+            preview: gif.media_formats.preview.url,
+            original: gif.media_formats[`${settings.tenor_file_detail}`].url,
+            width: gif.media_formats[`${settings.tenor_file_detail}`].dims[0],
+            height: gif.media_formats[`${settings.tenor_file_detail}`].dims[1],
           }));
         }
 
@@ -101,7 +101,7 @@ export default Controller.extend(ModalFunctionality, {
           "offset",
           settings.api_provider === "giphy"
             ? data.pagination.count + data.pagination.offset
-            : data.next
+            : data.next === "" ? 0 : data.next
         );
 
         this.currentGifs.addObjects(images);
@@ -125,15 +125,16 @@ export default Controller.extend(ModalFunctionality, {
   getEndpoint(query, offset) {
     if (settings.api_provider === "tenor") {
       return (
-        "https://g.tenor.com/v1/search?" +
+        "https://tenor.googleapis.com/v2/search?" +
         $.param({
           limit: 24,
           q: query,
           pos: offset,
-          media_filter: "default",
+          media_filter: settings.tenor_file_detail + ",preview",
           key: settings.tenor_api_key,
           locale: settings.giphy_locale,
           contentfilter: settings.tenor_content_filter,
+          client_key: settings.tenor_client_key
         })
       );
     } else {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,7 +6,7 @@ en:
     composer_title: "Search GIFs"
     no_results: "Enter a keyword in the input box above to search for GIFs."
     bad_api_key: >
-      Missing or Invalid {{api_provider}} API Key set. 
+      Missing or Invalid $api_provider API Key set. 
       Ask the site admin to follow the install instructions at 
       <a href='https://meta.discourse.org/t/discourse-gifs-component/158738'>
         https://meta.discourse.org/t/discourse-gifs-component/158738

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,7 +6,7 @@ en:
     composer_title: "Search GIFs"
     no_results: "Enter a keyword in the input box above to search for GIFs."
     bad_api_key: >
-      Missing or Invalid $api_provider API Key set. 
+      Missing or Invalid $api_provider API Key. 
       Ask the site admin to follow the install instructions at 
       <a href='https://meta.discourse.org/t/discourse-gifs-component/158738'>
         https://meta.discourse.org/t/discourse-gifs-component/158738

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,5 +4,13 @@ en:
     query: "Term"
     insert: "Insert Selected Images"
     composer_title: "Search GIFs"
-    bad_api_key: "Missing or wrong Giphy API Key set. Ask the site admin to follow the install instructions at <a href='https://meta.discourse.org/t/discourse-gifs-component/158738'>https://meta.discourse.org/t/discourse-gifs-component/158738</a>."
     no_results: "Enter a keyword in the input box above to search for GIFs."
+    bad_api_key: >
+      Missing or Invalid {{api_provider}} API Key set. 
+      Ask the site admin to follow the install instructions at 
+      <a href='https://meta.discourse.org/t/discourse-gifs-component/158738'>
+        https://meta.discourse.org/t/discourse-gifs-component/158738
+      </a>.
+    error_rate_limit: "We have reached our API Rate Limits. Please wait and try again later. If this issues persists, contact your site admin."
+    error_search_too_long: "Please shorten your search query to under 50 characters and try again."
+      

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -11,6 +11,6 @@ en:
       <a href='https://meta.discourse.org/t/discourse-gifs-component/158738'>
         https://meta.discourse.org/t/discourse-gifs-component/158738
       </a>.
-    error_rate_limit: "We have reached our API Rate Limits. Please wait and try again later. If this issues persists, contact your site admin."
+    error_rate_limit: "We have reached our API Rate Limits. Please wait and try again later. If this issue persists, contact your site admin."
     error_search_too_long: "Please shorten your search query to under 50 characters and try again."
       

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,12 +5,7 @@ en:
     insert: "Insert Selected Images"
     composer_title: "Search GIFs"
     no_results: "Enter a keyword in the input box above to search for GIFs."
-    bad_api_key: >
-      Missing or Invalid $api_provider API Key. 
-      Ask the site admin to follow the install instructions at 
-      <a href='https://meta.discourse.org/t/discourse-gifs-component/158738'>
-        https://meta.discourse.org/t/discourse-gifs-component/158738
-      </a>.
-    error_rate_limit: "We have reached our API Rate Limits. Please wait and try again later. If this issue persists, contact your site admin."
+    bad_api_key: "Invalid $api_provider API Key. Site admins, please check your key and/or your $api_provider account."
+    error_rate_limit: "We have reached our $api_provider API Rate Limits. Please wait and try again later. If this issue persists, contact your site admin."
     error_search_too_long: "Please shorten your search query to under 50 characters and try again."
       

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discourse-gifs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": "https://github.com/discourse/discourse-gifs",
   "author": "Discourse",
   "license": "MIT",

--- a/settings.yml
+++ b/settings.yml
@@ -121,7 +121,7 @@ tenor_content_filter:
   default: high
   description:
     en: >
-      TENOR: Content safety level for Tenor results. Find more info at 
+      TENOR: Content safety level for Tenor results. Find more info in 
       <a href="https://developers.google.com/tenor/guides/content-filtering">Tenor API Guides</a>.
   choices:
     - high
@@ -140,7 +140,7 @@ tenor_v2_locale:
   default: "en_US"
   description:
     en: >
-      TENOR V2: Language to use on the search. Country code (optional) can be provided to differentiate between dialects. 
+      TENOR V2: Language to use on the search. Country code (optional) can be provided to differentiate between dialects.<br/><br/>
       Format must be in "xx_YY" where "xx" is the <b>required</b> 
       <a href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">language code</a> 
       and "_YY" is the <b>optional</b> 
@@ -150,13 +150,17 @@ tenor_v2_locale:
 use_additional_error_handling:
   type: bool
   default: false
-  description: "Show custom error messages for Rate Limits & Search Query Too Long to users instead of the response from the API."
+  description: 'Show custom error messages for "Rate Limits - gif.error_rate_limit" & "Search Query Too Long - gif.error_search_too_long" to users instead of the response from the API.'
 allow_unlimited_search:
   type: bool
   default: true
   description:
-    en: "When set to true, we will search every time the user reaches the end of the results with no limits set. When set to false, we will continue searching similarly until we hit the Max Results Limit."
+    en: >
+      When enabled, we will search every time the user reaches the end of the results with no limits set.<br/>
+      When disabled, we will continue searching similarly until we hit the Max Results Limit.
 max_results_limit:
   type: integer
   min: 24
   default: 100
+  description:
+    en: 'When "allow unlimited search" is enabled, we will search until we get this number of maximum GIF results.'

--- a/settings.yml
+++ b/settings.yml
@@ -2,7 +2,7 @@ api_provider:
   default: "giphy"
   type: "enum"
   description:
-    en: "Which gifs provider should we use"
+    en: "Which GIF provider should we use?"
   choices:
     - giphy
     - tenor
@@ -10,22 +10,34 @@ giphy_api_key:
   type: string
   default: ""
   description:
-    en: "GIPHY API key"
-tenor_api_key:
-  type: string
-  default: ""
+    en: "GIPHY: API key"
+giphy_file_format:
+  type: enum
+  default: webp
   description:
-    en: "TENOR API key"
-tenor_client_key:
-  type: string
-  default: "Discourse"
+    en: "GIPHY: Image format to use. WEBP has smaller files that load quicker while GIF provides compatibility with old browsers."
+  choices:
+    - webp
+    - gif
+giphy_content_rating:
+  type: enum
+  default: r
   description:
-    en: "TENOR - client-specified string that represents the integration"
+    en: >
+      GIPHY: Content rating for search results, more info at 
+      <a href="https://developers.giphy.com/docs/optional-settings#rating">
+        https://developers.giphy.com/docs/optional-settings#rating
+      </a>.
+  choices:
+    - g
+    - pg
+    - pg-13
+    - r
 giphy_locale:
   type: enum
   default: en
   description:
-    en: "Language to use on the search. Used to cater search to regional content. Set to your default forum locale."
+    en: "GIPHY & TENOR V1: Language to use on the search. Used to cater search to regional content. Set to your default forum locale."
   choices:
     - ar
     - bn
@@ -59,41 +71,92 @@ giphy_locale:
     - vi
     - zh-CN
     - zh-TW
-giphy_file_format:
-  type: enum
-  default: webp
+tenor_api_key:
+  type: string
+  default: ""
   description:
-    en: "GIPHY: Image format to use. WEBP has smaller files that load quicker while GIF provides compatibility with old browsers."
+    en: >
+      TENOR: API key. 
+      <ul>
+        <li>v1 API Key can no longer be generated. Legacy users only.</li>
+        <li>V2 key can be generated from <a href="https://console.cloud.google.com/apis/library/tenor.googleapis.com">Google Cloud</a>.</li>
+      <ul>
+tenor_api_version:
+  type: enum
+  description:
+    en: >
+      TENOR: API Version
+      <ul>
+        <li>v1-legacy = Legacy (no longer accepting new registrations)</li>
+        <li>v2-gcp = Google Cloud</li>
+      <ul>
   choices:
-    - webp
-    - gif
+    - v1-legacy
+    - v2-gcp
+  default: v1-legacy
+tenor_client_key:
+  type: string
+  default: "discourse"
+  description:
+    en: "TENOR: client-specified string that represents the integration"
 tenor_file_detail:
   type: enum
-  default: mediumgif
+  default: gif
   description:
-    en: "TENOR: Image format to use. gif = High-quality GIF format | mediumgif = small reduction, same size | tinygif = up to 220px wide | nanogif = up to 90 pixels tall"
+    en: >
+      TENOR: Image format to use 
+      <ul>
+        <li>gif = High-quality GIF format</li>
+        <li>mediumgif = same height/width with small size reduction</li>
+        <li>tinygif = up to 220px wide</li>
+        <li>nanogif = up to 90 pixels tall</li>
+      <ul>
   choices:
     - gif
     - mediumgif
     - tinygif
     - nanogif
-giphy_content_rating:
-  type: enum
-  default: r
-  description:
-    en: 'GIPHY: Content rating for search results, more info at <a href="https://developers.giphy.com/docs/optional-settings#rating">https://developers.giphy.com/docs/optional-settings#rating</a>.'
-  choices:
-    - g
-    - pg
-    - pg-13
-    - r
 tenor_content_filter:
   type: "enum"
   default: high
   description:
-    en: "TENOR: Content safety level for Tenor results"
+    en: >
+      TENOR: Content safety level for Tenor results. Find more info at 
+      <a href="https://developers.google.com/tenor/guides/content-filtering">Tenor API Guides</a>.
   choices:
     - high
     - medium
     - low
     - "off"
+tenor_v2_country:
+  type: string
+  default: "US"
+  description:
+    en: >
+      TENOR V2: Two-Letter Country of Origin for the request. Find your country code in 
+      <a href="https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes">Wikipedia - ISO_3166-1</a>.
+tenor_v2_locale:
+  type: string
+  default: "en_US"
+  description:
+    en: >
+      TENOR V2: Language to use on the search. Country code (optional) can be provided to differentiate between dialects. 
+      Format must be in "xx_YY" where "xx" is the <b>required</b> 
+      <a href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">language code</a> 
+      and "_YY" is the <b>optional</b> 
+      <a href="https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes">country code</a>. 
+      Find info on Tenor localization in 
+      <a href="https://developers.google.com/tenor/guides/localization">Tenor API Guides</a>.
+use_additional_error_handling:
+  type: bool
+  default: false
+  description: "Show custom error messages for Rate Limits & Search Query Too Long to users instead of the response from the API."
+allow_unlimited_search:
+  type: bool
+  default: true
+  description:
+    en: "When set to true, we will search every time the user reaches the end of the results with no limits set. When set to false, we will continue searching similarly until we hit the Max Results Limit."
+max_results_limit:
+  type: integer
+  min: 24
+  default: 100

--- a/settings.yml
+++ b/settings.yml
@@ -37,7 +37,7 @@ giphy_locale:
   type: enum
   default: en
   description:
-    en: "GIPHY & TENOR V1: Language to use on the search. Used to cater search to regional content. Set to your default forum locale."
+    en: "GIPHY & Tenor V1: Language to use on the search. Used to cater search to regional content. Set to your default forum locale."
   choices:
     - ar
     - bn
@@ -71,40 +71,41 @@ giphy_locale:
     - vi
     - zh-CN
     - zh-TW
+allow_unlimited_search:
+  type: bool
+  default: true
+  description:
+    en: >
+      Tenor & GIPHY: When enabled, we will run a continuous search with infinite scrolling every time the user reaches the end of the results with no limits set.<br/>
+      When disabled, we will continue searching similarly until we hit the Max Results Limit.
+max_results_limit:
+  type: integer
+  min: 24
+  default: 240
+  description:
+    en: 'Tenor & GIPHY: When "allow unlimited search" is enabled, we will search until we get this number of maximum GIF results. Each API call retrieves 24 results, e.g. 240 Max Limit: 240 / 24 = 10 API Calls.'
 tenor_api_key:
   type: string
   default: ""
   description:
     en: >
-      TENOR: API key. 
-      <ul>
-        <li>v1 API Key can no longer be generated. Legacy users only.</li>
-        <li>V2 key can be generated from <a href="https://console.cloud.google.com/apis/library/tenor.googleapis.com">Google Cloud</a>.</li>
-      <ul>
-tenor_api_version:
-  type: enum
-  description:
-    en: >
-      TENOR: API Version
-      <ul>
-        <li>v1-legacy = Legacy (no longer accepting new registrations)</li>
-        <li>v2-gcp = Google Cloud</li>
-      <ul>
-  choices:
-    - v1-legacy
-    - v2-gcp
-  default: v1-legacy
+      Tenor: V2 API Key. Instructions to get one can be found in
+        <a href='https://meta.discourse.org/t/discourse-gifs-component/158738'>
+          Discourse Meta - Discourse Gifs
+        </a>.
+      <br/><br/>
+      <b><i>Attention: Legacy Tenor V1 API users - please generate a V2 API Key</i><b>
 tenor_client_key:
   type: string
   default: "discourse"
   description:
-    en: "TENOR: client-specified string that represents the integration"
+    en: "Tenor: (optional) client-specified string that represents the integration"
 tenor_file_detail:
   type: enum
   default: gif
   description:
     en: >
-      TENOR: Image format to use 
+      Tenor: Image format to use 
       <ul>
         <li>gif = High-quality GIF format</li>
         <li>mediumgif = same height/width with small size reduction</li>
@@ -121,46 +122,29 @@ tenor_content_filter:
   default: high
   description:
     en: >
-      TENOR: Content safety level for Tenor results. Find more info in 
+      Tenor: Content safety level for Tenor results. Find more info in 
       <a href="https://developers.google.com/tenor/guides/content-filtering">Tenor API Guides</a>.
   choices:
     - high
     - medium
     - low
     - "off"
-tenor_v2_country:
+tenor_country:
   type: string
   default: "US"
   description:
     en: >
-      TENOR V2: Two-Letter Country of Origin for the request. Find your country code in 
+      Tenor: Two-Letter Country of Origin for the request. Find your country code in 
       <a href="https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes">Wikipedia - ISO_3166-1</a>.
-tenor_v2_locale:
+tenor_locale:
   type: string
   default: "en_US"
   description:
     en: >
-      TENOR V2: Language to use on the search. Country code (optional) can be provided to differentiate between dialects.<br/><br/>
+      Tenor: Language to use on the search. Country code (optional) can be provided to differentiate between dialects.<br/><br/>
       Format must be in "xx_YY" where "xx" is the <b>required</b> 
       <a href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">language code</a> 
       and "_YY" is the <b>optional</b> 
       <a href="https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes">country code</a>. 
       Find info on Tenor localization in 
       <a href="https://developers.google.com/tenor/guides/localization">Tenor API Guides</a>.
-use_additional_error_handling:
-  type: bool
-  default: false
-  description: 'Show custom error messages for "Rate Limits - gif.error_rate_limit" & "Search Query Too Long - gif.error_search_too_long" to users instead of the response from the API.'
-allow_unlimited_search:
-  type: bool
-  default: true
-  description:
-    en: >
-      When enabled, we will search every time the user reaches the end of the results with no limits set.<br/>
-      When disabled, we will continue searching similarly until we hit the Max Results Limit.
-max_results_limit:
-  type: integer
-  min: 24
-  default: 100
-  description:
-    en: 'When "allow unlimited search" is enabled, we will search until we get this number of maximum GIF results.'

--- a/settings.yml
+++ b/settings.yml
@@ -69,26 +69,14 @@ giphy_file_format:
     - gif
 tenor_file_detail:
   type: enum
-  default: webp_transparent
+  default: mediumgif
   description:
-    en: "TENOR: Image format to use. WEBP has smaller files that load quicker while GIF provides compatibility with old browsers."
+    en: "TENOR: Image format to use. gif = High-quality GIF format | mediumgif = small reduction, same size | tinygif = up to 220px wide | nanogif = up to 90 pixels tall"
   choices:
     - gif
     - mediumgif
     - tinygif
     - nanogif
-    - gif_transparent
-    - tinygif_transparent
-    - nanogif_transparent
-    - webp_transparent
-    - tinywebp_transparent
-    - nanowebp_transparent
-    - mp4
-    - loopedmp4
-    - tinymp4
-    - webm
-    - tinywebm
-    - nanowebm
 giphy_content_rating:
   type: enum
   default: r

--- a/settings.yml
+++ b/settings.yml
@@ -24,8 +24,8 @@ giphy_content_rating:
   default: r
   description:
     en: >
-      GIPHY: Content rating for search results, more info at 
-      <a href="https://developers.giphy.com/docs/optional-settings#rating">
+      GIPHY: Content rating for search results. Find more info at 
+      <a target="_blank" rel="noreferrer noopener" href="https://developers.giphy.com/docs/optional-settings#rating">
         https://developers.giphy.com/docs/optional-settings#rating
       </a>.
   choices:
@@ -71,30 +71,28 @@ giphy_locale:
     - vi
     - zh-CN
     - zh-TW
-allow_unlimited_search:
+limit_infinite_search_results:
   type: bool
-  default: true
+  default: false
   description:
-    en: >
-      Tenor & GIPHY: When enabled, we will run a continuous search with infinite scrolling every time the user reaches the end of the results with no limits set.<br/>
-      When disabled, we will continue searching similarly until we hit the Max Results Limit.
+    en: "Limit the number of GIF results returned as the user scrolls infinitely to prevent API Rate Limiting."
 max_results_limit:
   type: integer
   min: 24
   default: 240
   description:
-    en: 'Tenor & GIPHY: When "allow unlimited search" is enabled, we will search until we get this number of maximum GIF results. Each API call retrieves 24 results, e.g. 240 Max Limit: 240 / 24 = 10 API Calls.'
+    en: 'Tenor & GIPHY: When "limit infinite search results" is enabled, we will search until we get this number of maximum GIF results. Each API call retrieves 24 results, <i>e.g. 240 Max Limit: 240 / 24 = 10 API Calls</i>.'
 tenor_api_key:
   type: string
   default: ""
   description:
     en: >
       Tenor: V2 API Key. Instructions to get one can be found in
-        <a href='https://meta.discourse.org/t/discourse-gifs-component/158738'>
+        <a target="_blank" rel="noreferrer noopener" href='https://meta.discourse.org/t/discourse-gifs-component/158738'>
           Discourse Meta - Discourse Gifs
         </a>.
       <br/><br/>
-      <b><i>Attention: Legacy Tenor V1 API users - please generate a V2 API Key</i><b>
+      <b>Attention: Legacy Tenor V1 API users - please generate a new V2 API Key</b>
 tenor_client_key:
   type: string
   default: "discourse"
@@ -123,7 +121,9 @@ tenor_content_filter:
   description:
     en: >
       Tenor: Content safety level for Tenor results. Find more info in 
-      <a href="https://developers.google.com/tenor/guides/content-filtering">Tenor API Guides</a>.
+      <a target="_blank" rel="noreferrer noopener" href="https://developers.google.com/tenor/guides/content-filtering">
+        Tenor API Guides
+      </a>.
   choices:
     - high
     - medium
@@ -135,7 +135,9 @@ tenor_country:
   description:
     en: >
       Tenor: Two-Letter Country of Origin for the request. Find your country code in 
-      <a href="https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes">Wikipedia - ISO_3166-1</a>.
+      <a target="_blank" rel="noreferrer noopener" href="https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes">
+        Wikipedia - ISO_3166-1
+      </a>.
 tenor_locale:
   type: string
   default: "en_US"
@@ -143,8 +145,14 @@ tenor_locale:
     en: >
       Tenor: Language to use on the search. Country code (optional) can be provided to differentiate between dialects.<br/><br/>
       Format must be in "xx_YY" where "xx" is the <b>required</b> 
-      <a href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">language code</a> 
+      <a target="_blank" rel="noreferrer noopener" href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">
+        language code
+      </a> 
       and "_YY" is the <b>optional</b> 
-      <a href="https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes">country code</a>. 
+      <a target="_blank" rel="noreferrer noopener" href="https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes">
+        country code
+      </a>. 
       Find info on Tenor localization in 
-      <a href="https://developers.google.com/tenor/guides/localization">Tenor API Guides</a>.
+      <a target="_blank" rel="noreferrer noopener" href="https://developers.google.com/tenor/guides/localization">
+        Tenor API Guides
+      </a>.

--- a/settings.yml
+++ b/settings.yml
@@ -37,7 +37,7 @@ giphy_locale:
   type: enum
   default: en
   description:
-    en: "GIPHY & Tenor V1: Language to use on the search. Used to cater search to regional content. Set to your default forum locale."
+    en: "GIPHY: Language to use on the search. Used to cater search to regional content. Set to your default forum locale."
   choices:
     - ar
     - bn

--- a/settings.yml
+++ b/settings.yml
@@ -16,6 +16,11 @@ tenor_api_key:
   default: ""
   description:
     en: "TENOR API key"
+tenor_client_key:
+  type: string
+  default: "Discourse"
+  description:
+    en: "TENOR - client-specified string that represents the integration"
 giphy_locale:
   type: enum
   default: en
@@ -64,14 +69,26 @@ giphy_file_format:
     - gif
 tenor_file_detail:
   type: enum
-  default: gif
+  default: webp_transparent
   description:
-    en: "TENOR: Image detail to use for Tenors."
+    en: "TENOR: Image format to use. WEBP has smaller files that load quicker while GIF provides compatibility with old browsers."
   choices:
     - gif
     - mediumgif
     - tinygif
     - nanogif
+    - gif_transparent
+    - tinygif_transparent
+    - nanogif_transparent
+    - webp_transparent
+    - tinywebp_transparent
+    - nanowebp_transparent
+    - mp4
+    - loopedmp4
+    - tinymp4
+    - webm
+    - tinywebm
+    - nanowebm
 giphy_content_rating:
   type: enum
   default: r


### PR DESCRIPTION
- Tenor V1 API Support has been replaced with V2 API. You must get a new V2 API Key from Google Cloud.
- New Settings specific to Tenor have been added: Client Key, Locale & Country
- New Settings to limit infinite scrolling along with max number of search results. This will prevent API Rate Limits & misuse
- Additional Error Handling around conversion of Tenor V2 API Error Messages to readable format, catching missing API keys prior to calling API Provider, Rate Limits & Search Query Length limits
- Added variable support for `$api_provider` to include provider name in error messages.