### PR TITLE
DEV: Convert Gif button to Glimmer component

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,1 +1,2 @@
 2.7.0.beta5: a7424adc3912a31143080bbf0a1d2002c73beaff
+2.9.0.beta1: 31da2ef319e2a26ef953be6fafc150e82c64d3be

--- a/javascripts/discourse/components/gif-button.js
+++ b/javascripts/discourse/components/gif-button.js
@@ -1,10 +1,10 @@
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { showGifModal } from "../helpers/gif-modal";
+import { action } from "@ember/object";
 
-export default Component.extend({
-  tagName: "",
-
-  actions: {
-    showGifModal,
-  },
-});
+export default class GifButton extends Component {
+  @action
+  showGifModal() {
+    showGifModal();
+  }
+}

--- a/javascripts/discourse/templates/components/gif-button.hbs
+++ b/javascripts/discourse/templates/components/gif-button.hbs
@@ -1,8 +1,8 @@
 <a
   href
   class="btn btn-default no-text mobile-gif-insert"
-  aria-label={{i18n "gif.composer_title"}}
-  {{action "showGifModal"}}
+  aria-label={{theme-i18n "gif.composer_title"}}
+  {{on "click" this.showGifModal}}
 >
   {{d-icon "discourse-gifs-gif"}}
 </a>


### PR DESCRIPTION
This is a generally useful modernization, and also works around a current bug in Discourse core with the `{{action` modifier.

This also fixes the aria-label on the button, which was previously rendering a missing translation placeholder.