### PR TITLE
FIX: Ensure gif button does not trigger a page load

### DIFF
--- a/javascripts/discourse/templates/components/gif-button.hbs
+++ b/javascripts/discourse/templates/components/gif-button.hbs
@@ -1,4 +1,5 @@
 <button
+  type="button"
   class="btn btn-default no-text mobile-gif-insert"
   aria-label={{theme-i18n "gif.composer_title"}}
   {{on "click" this.showGifModal}}

--- a/javascripts/discourse/templates/components/gif-button.hbs
+++ b/javascripts/discourse/templates/components/gif-button.hbs
@@ -1,8 +1,7 @@
-<a
-  href
+<button
   class="btn btn-default no-text mobile-gif-insert"
   aria-label={{theme-i18n "gif.composer_title"}}
   {{on "click" this.showGifModal}}
 >
   {{d-icon "discourse-gifs-gif"}}
-</a>
+</button>


### PR DESCRIPTION
We could `event.preventDefault()` and keep the `<a`, but `<button` is more semantically correct and visually looks the same.

Followup to d70fbe0b5aa18a97f4de7e79b4de134b674c6ec5