### PR TITLE
UX: Use minimasonry for layout of GIFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This theme component add a button to the composer that allows you to search for gifs and easily add the best one to your post.
 
 To learn more, check out: https://meta.discourse.org/t/discourse-gifs-component/158738
+
+### Developers
+
+This repository uses the Minimasonry library to lay out the GIFs when selecting. Use `yarn run copy-masonry` to update the package.

--- a/common/common.scss
+++ b/common/common.scss
@@ -18,6 +18,10 @@ html:not(.discourse-gifs-with-img)
 }
 
 .gif-modal {
+  .modal-inner-container {
+    --modal-max-width: 90vw; // overrides core
+  }
+
   .gif-input {
     background: var(--primary-very-low);
     padding: 0.5em;
@@ -35,39 +39,22 @@ html:not(.discourse-gifs-with-img)
   }
 
   .gif-content {
-    height: calc(100% - 50px);
     overflow-y: auto;
     min-width: 320px;
-    max-height: 350px;
+    max-height: 65vh;
+    margin-top: 0.5em;
   }
   .gif-box {
     .gif-result-list {
-      padding-top: 1em;
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      // TODO: Use this once support is more widespread
-      // grid-template-rows: masonry;
-      grid-gap: 0.6em;
-      grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-      grid-auto-rows: 25px;
+      position: relative;
       .gif-imgwrap {
-        grid-row-end: span 3;
-        overflow: hidden;
-        background: var(--primary-very-low);
+        position: absolute;
         img {
-          max-width: 100%;
+          width: 100%;
+          height: auto;
+          cursor: pointer;
         }
       }
-      .tall-one {
-        grid-row-end: span 6;
-      }
-      .tall-two {
-        grid-row-end: span 4;
-      }
-    }
-    div[data-theme-discourse-gifs="container"],
-    div[data-theme-discourse-gifs="webp-container"] {
-      display: inline-block;
     }
     div.loading-container {
       display: block;
@@ -76,16 +63,11 @@ html:not(.discourse-gifs-with-img)
   }
 
   .gif-no-results {
-    width: 100%;
-    height: 210px;
-    box-sizing: border-box;
-    padding: 2em;
+    padding: 3em 1em;
+    font-size: var(--font-up-2);
+    color: var(--primary-low-mid);
     background: var(--primary-very-low);
-    font-size: var(--font-up-1);
-    color: var(--primary-medium);
     font-weight: bold;
-    display: flex;
-    align-items: center;
     text-align: center;
   }
 

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,4 +1,9 @@
 .gif-modal .gif-content {
-  min-width: 650px;
-  max-height: 420px;
+  min-width: 650px; // 3 columns of gifs
+}
+
+@media screen and (min-width: 1200px) {
+  .gif-modal .gif-content {
+    min-width: 860px; // 4 columns of gifs
+  }
 }

--- a/javascripts/discourse/components/gif-result-list.js
+++ b/javascripts/discourse/components/gif-result-list.js
@@ -1,13 +1,18 @@
 import Component from "@ember/component";
+import MiniMasonry from "../lib/minimasonry";
+import { next } from "@ember/runloop";
 
 export default Component.extend({
   tagName: "div",
   classNames: ["gif-result-list"],
   observer: null,
+  masonry: null,
 
   _setupInfiniteScrolling() {
     this.observer = new IntersectionObserver(() => {
-      if (this.content && this.content.length > 0) {
+      const scroller = document.querySelector(".gif-content");
+      // ensure we don't load more if we haven't scrolled at all
+      if (scroller?.scrollTop > 0 && this.content?.length > 0) {
         this.loadMore();
       }
     });
@@ -17,7 +22,27 @@ export default Component.extend({
   },
 
   didInsertElement() {
+    this._super(...arguments);
     this._setupInfiniteScrolling();
+
+    this.masonry = new MiniMasonry({
+      container: ".gif-result-list",
+      baseWidth: this.site.mobileView ? 145 : 200,
+      surroundingGutter: false,
+    });
+
+    this.rearrangeMasonry();
+  },
+
+  didUpdateAttrs() {
+    this._super(...arguments);
+    this.rearrangeMasonry();
+  },
+
+  rearrangeMasonry() {
+    next(() => {
+      this.masonry.layout();
+    });
   },
 
   willDestroyElement() {

--- a/javascripts/discourse/components/gif-result.js
+++ b/javascripts/discourse/components/gif-result.js
@@ -1,22 +1,19 @@
 import discourseComputed from "discourse-common/utils/decorators";
 import Component from "@ember/component";
+import { htmlSafe } from "@ember/template";
 
 export default Component.extend({
   tagName: "div",
   classNames: ["gif-imgwrap"],
-  classNameBindings: ["tallOne", "tallTwo"],
   attributeBindings: ["role", "tabindex"],
   role: "button",
   tabindex: 0,
 
-  @discourseComputed("gif.height", "gif.width")
-  tallOne(height, width) {
-    return height / width > 1.5;
-  },
-
-  @discourseComputed("gif.height", "gif.width")
-  tallTwo(height, width) {
-    return height / width > 1 && height / width < 1.5;
+  @discourseComputed("gif.width", "gif.height")
+  style(width, height) {
+    if (width && height) {
+      return htmlSafe(`--aspect-ratio: ${width / height};`);
+    }
   },
 
   keyDown(event) {

--- a/javascripts/discourse/lib/minimasonry.js
+++ b/javascripts/discourse/lib/minimasonry.js
@@ -1,0 +1,239 @@
+var MiniMasonry = function(conf) {
+    this._sizes             = [];
+    this._columns           = [];
+    this._container         = null;
+    this._count             = null;
+    this._width             = 0;
+    this._removeListener    = null;
+    this._currentGutterX    = null;
+    this._currentGutterY    = null;
+
+    this._resizeTimeout = null,
+
+    this.conf = {
+        baseWidth: 255,
+        gutterX: null,
+        gutterY: null,
+        gutter: 10,
+        container: null,
+        minify: true,
+        ultimateGutter: 5,
+        surroundingGutter: true,
+        direction: 'ltr',
+        wedge: false
+    };
+
+    this.init(conf);
+
+    return this;
+}
+
+MiniMasonry.prototype.init = function(conf) {
+    for (var i in this.conf) {
+        if (conf[i] != undefined) {
+            this.conf[i] = conf[i];
+        }
+    }
+
+    if (this.conf.gutterX == null || this.conf.gutterY == null) {
+        this.conf.gutterX = this.conf.gutterY = this.conf.gutter;
+    }
+    this._currentGutterX = this.conf.gutterX;
+    this._currentGutterY = this.conf.gutterY;
+
+    this._container = typeof this.conf.container == 'object' && this.conf.container.nodeName ?
+        this.conf.container :
+        document.querySelector(this.conf.container);
+
+    if (!this._container) {
+        throw new Error('Container not found or missing');
+    }
+
+    var onResize = this.resizeThrottler.bind(this)
+    window.addEventListener("resize", onResize);
+    this._removeListener = function() {
+        window.removeEventListener("resize", onResize);
+        if (this._resizeTimeout != null) {
+            window.clearTimeout(this._resizeTimeout);
+            this._resizeTimeout = null;
+        }
+    }
+
+    this.layout();
+};
+
+MiniMasonry.prototype.reset = function() {
+    this._sizes   = [];
+    this._columns = [];
+    this._count   = null;
+    this._width   = this._container.clientWidth;
+    var minWidth  = this.conf.baseWidth;
+    if (this._width < minWidth) {
+        this._width = minWidth;
+        this._container.style.minWidth = minWidth + 'px';
+    }
+
+    if (this.getCount() == 1) {
+        // Set ultimate gutter when only one column is displayed
+        this._currentGutterX = this.conf.ultimateGutter;
+        // As gutters are reduced, two column may fit, forcing to 1
+        this._count = 1;
+    } else if (this._width < (this.conf.baseWidth + (2 * this._currentGutterX))) {
+        // Remove gutter when screen is to low
+        this._currentGutterX = 0;
+    } else {
+        this._currentGutterX = this.conf.gutterX;
+    }
+};
+
+MiniMasonry.prototype.getCount = function() {
+    if (this.conf.surroundingGutter) {
+        return Math.floor((this._width - this._currentGutterX) / (this.conf.baseWidth + this._currentGutterX));
+    }
+
+    return Math.floor((this._width + this._currentGutterX) / (this.conf.baseWidth + this._currentGutterX));
+}
+
+MiniMasonry.prototype.computeWidth = function() {
+    var width;
+    if (this.conf.surroundingGutter) {
+        width = ((this._width - this._currentGutterX) / this._count) - this._currentGutterX;
+    } else {
+        width = ((this._width + this._currentGutterX) / this._count) - this._currentGutterX;
+    }
+    width = Number.parseFloat(width.toFixed(2));
+
+    return width;
+}
+
+MiniMasonry.prototype.layout =  function() {
+    if (!this._container) {
+        console.error('Container not found');
+        return;
+    }
+    this.reset();
+
+    //Computing columns count
+    if (this._count == null) {
+        this._count = this.getCount();
+    }
+    //Computing columns width
+    var colWidth = this.computeWidth();
+
+    for (var i = 0; i < this._count; i++) {
+        this._columns[i] = 0;
+    }
+
+    //Saving children real heights
+    var children = this._container.children;
+    for (var k = 0;k< children.length; k++) {
+        // Set colWidth before retrieving element height if content is proportional
+        children[k].style.width = colWidth + 'px';
+        this._sizes[k] = children[k].clientHeight;
+    }
+
+    var startX;
+    if (this.conf.direction == 'ltr') {
+        startX = this.conf.surroundingGutter ? this._currentGutterX : 0;
+    } else {
+        startX = this._width - (this.conf.surroundingGutter ? this._currentGutterX : 0);
+    }
+    if (this._count > this._sizes.length) {
+        //If more columns than children
+        var occupiedSpace = (this._sizes.length * (colWidth + this._currentGutterX)) - this._currentGutterX;
+        if (this.conf.wedge === false) {
+            if (this.conf.direction == 'ltr') {
+                startX = ((this._width - occupiedSpace) / 2);
+            } else {
+                startX = this._width - ((this._width - occupiedSpace) / 2);
+            }
+        } else {
+            if (this.conf.direction == 'ltr') {
+                //
+            } else {
+                startX = this._width - this._currentGutterX;
+            }
+        }
+    }
+
+    //Computing position of children
+    for (var index = 0;index < children.length; index++) {
+        var nextColumn = this.conf.minify ? this.getShortest() : this.getNextColumn(index);
+
+        var childrenGutter = 0;
+        if (this.conf.surroundingGutter || nextColumn != this._columns.length) {
+            childrenGutter = this._currentGutterX;
+        }
+        var x;
+        if (this.conf.direction == 'ltr') {
+            x = startX + ((colWidth + childrenGutter) * (nextColumn));
+        } else {
+            x = startX - ((colWidth + childrenGutter) * (nextColumn)) - colWidth;
+        }
+        var y = this._columns[nextColumn];
+
+
+        children[index].style.transform = 'translate3d(' + Math.round(x) + 'px,' + Math.round(y) + 'px,0)';
+
+        this._columns[nextColumn] += this._sizes[index] + (this._count > 1 ? this.conf.gutterY : this.conf.ultimateGutter);//margin-bottom
+    }
+
+    this._container.style.height = (this._columns[this.getLongest()] - this._currentGutterY) + 'px';
+};
+
+MiniMasonry.prototype.getNextColumn = function(index) {
+    return index % this._columns.length;
+};
+
+MiniMasonry.prototype.getShortest = function() {
+    var shortest = 0;
+    for (var i = 0; i < this._count; i++) {
+        if (this._columns[i] < this._columns[shortest]) {
+            shortest = i;
+        }
+    }
+
+    return shortest;
+};
+
+MiniMasonry.prototype.getLongest = function() {
+    var longest = 0;
+    for (var i = 0; i < this._count; i++) {
+        if (this._columns[i] > this._columns[longest]) {
+            longest = i;
+        }
+    }
+
+    return longest;
+};
+
+MiniMasonry.prototype.resizeThrottler = function() {
+    // ignore resize events as long as an actualResizeHandler execution is in the queue
+    if ( !this._resizeTimeout ) {
+
+        this._resizeTimeout = setTimeout(function() {
+            this._resizeTimeout = null;
+            //IOS Safari throw random resize event on scroll, call layout only if size has changed
+            if (this._container.clientWidth != this._width) {
+                this.layout();
+            }
+           // The actualResizeHandler will execute at a rate of 30fps
+        }.bind(this), 33);
+    }
+}
+
+MiniMasonry.prototype.destroy = function() {
+    if (typeof this._removeListener == "function") {
+        this._removeListener();
+    }
+
+    var children = this._container.children;
+    for (var k = 0;k< children.length; k++) {
+        children[k].style.removeProperty('width');
+        children[k].style.removeProperty('transform');
+    }
+    this._container.style.removeProperty('height');
+    this._container.style.removeProperty('min-width');
+}
+
+export default MiniMasonry;

--- a/javascripts/discourse/templates/components/gif-result.hbs
+++ b/javascripts/discourse/templates/components/gif-result.hbs
@@ -1,8 +1,9 @@
-<div data-theme-discourse-gifs="webp-container">
-  <img
-    class="gif-img"
-    alt={{gif.title}}
-    title={{gif.title}}
-    src={{gif.preview}}
-  />
-</div>
+<img
+  class="gif-img"
+  alt={{gif.title}}
+  title={{gif.title}}
+  src={{gif.preview}}
+  style={{this.style}}
+  width={{gif.width}}
+  height={{gif.height}}
+/>

--- a/javascripts/discourse/templates/modal/gif.hbs
+++ b/javascripts/discourse/templates/modal/gif.hbs
@@ -12,8 +12,8 @@
     {{/if}}
   </div>
 
-  <div class="gif-content">
-    {{#if currentGifs}}
+  {{#if currentGifs}}
+    <div class="gif-content">
       <div class="gif-box">
         {{gif-result-list
           content=currentGifs
@@ -21,10 +21,10 @@
           loadMore=(action "loadMore")
         }}
       </div>
-    {{else}}
-      <div class="gif-no-results">{{theme-i18n "gif.no_results"}}</div>
-    {{/if}}
-  </div>
+    </div>
+  {{else}}
+    <div class="gif-no-results">{{theme-i18n "gif.no_results"}}</div>
+  {{/if}}
 {{/d-modal-body}}
 
 <div class="modal-footer gif-modal">

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "author": "Discourse",
   "license": "MIT",
   "devDependencies": {
-    "eslint-config-discourse": "^3.1.0"
+    "eslint-config-discourse": "^3.1.0",
+    "minimasonry": "^1.3.2"
+  },
+  "scripts": {
+    "copy-masonry": "cp node_modules/minimasonry/src/minimasonry.js javascripts/discourse/lib/minimasonry.js"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2125,6 +2125,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+minimasonry@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/minimasonry/-/minimasonry-1.3.2.tgz#16961ae9a271b1e99d6834dcb692347312a78100"
+  integrity sha512-ygvf5JIR4NT1LbM6o8z1oz1icTkta72gXKwidvSqIVxuzVd/P21UI0Wbq1J+MStAu50Vvr8qWYNSz1W4uycqMQ==
+
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"


### PR DESCRIPTION
Before/after screenshots

Desktop

<img width="1191" alt="image" src="https://github.com/discourse/discourse-gifs/assets/368961/d6982807-ea71-44c3-9aa4-231654f95b8b">

<img width="1314" alt="image" src="https://github.com/discourse/discourse-gifs/assets/368961/b33bda6b-1699-4b2b-b247-27244528b427">

Mobile

<img width="415" alt="image" src="https://github.com/discourse/discourse-gifs/assets/368961/8bf34b08-3e6a-4e02-b04f-b00aca520133">

<img width="386" alt="image" src="https://github.com/discourse/discourse-gifs/assets/368961/6a3d08c5-8dc2-4a26-bdc0-d74f972f52d8">
