### PR TITLE
UX: hide on profile, fix deprecations

### DIFF
--- a/javascripts/discourse/controllers/gif.js
+++ b/javascripts/discourse/controllers/gif.js
@@ -48,7 +48,7 @@ export default Controller.extend(ModalFunctionality, {
 
   @action
   refresh(query) {
-    this.set("query", query);
+    this.set("query", query.target.value);
     discourseDebounce(this, this.search, 700);
   },
 

--- a/javascripts/discourse/initializers/gif-integration.js
+++ b/javascripts/discourse/initializers/gif-integration.js
@@ -10,13 +10,15 @@ export default {
     withPluginApi("0.1", (api) => {
       if (!api.container.lookup("site:main").mobileView) {
         api.onToolbarCreate((toolbar) => {
-          toolbar.addButton({
-            title: themePrefix("gif.composer_title"),
-            id: "gif_button",
-            group: "extras",
-            icon: "discourse-gifs-gif",
-            action: showGifModal,
-          });
+          if (toolbar.context.composerEvents) {
+            toolbar.addButton({
+              title: themePrefix("gif.composer_title"),
+              id: "gif_button",
+              group: "extras",
+              icon: "discourse-gifs-gif",
+              action: showGifModal,
+            });
+          }
         });
       }
 

--- a/javascripts/discourse/templates/modal/gif.hbs
+++ b/javascripts/discourse/templates/modal/gif.hbs
@@ -1,11 +1,11 @@
 {{#d-modal-body id="gif-modal"}}
   <div class="gif-input">
-    {{input
+    <Input
       type="text"
       name="query"
-      autofocus="true"
-      key-up=(action "refresh")
-    }}
+      autofocus={{true}}
+      {{on "keyup" (action "refresh")}}
+    />
 
     {{#if loading}}
       {{loading-spinner size="small"}}

--- a/javascripts/discourse/templates/modal/gif.hbs
+++ b/javascripts/discourse/templates/modal/gif.hbs
@@ -1,7 +1,7 @@
 {{#d-modal-body id="gif-modal"}}
   <div class="gif-input">
     <Input
-      type="text"
+      @type="text"
       name="query"
       autofocus={{true}}
       {{on "keyup" (action "refresh")}}


### PR DESCRIPTION
We show the gif button on profile and group description inputs, but we don't allow images in those places. Checking the toolbar context avoids this. 

![Screenshot 2023-07-07 at 3 31 53 PM](https://github.com/discourse/discourse-gifs/assets/1681963/6c55973e-0e37-4b26-8cb7-c1f38bc8ded5)


I also noticed some deprecation warnings in the console so I fixed those. 