### PR TITLE
UX: sizing + scrollbar issue

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -18,8 +18,8 @@ html:not(.discourse-gifs-with-img)
 }
 
 .gif-modal {
-  .modal-inner-container {
-    --modal-max-width: 90vw; // overrides core
+  .d-modal__container {
+    --modal-max-width: 900px;
   }
 
   .gif-input {

--- a/javascripts/discourse/components/modal/gif.hbs
+++ b/javascripts/discourse/components/modal/gif.hbs
@@ -2,7 +2,7 @@
   @title={{theme-i18n "gif.modal_title"}}
   @closeModal={{@closeModal}}
   id="gif-modal"
-  class="gif-modal -large"
+  class="gif-modal"
 >
   <:body>
     <div class="gif-input">


### PR DESCRIPTION
Horizontal scroll appeared because the modal wasn't wide enough. Because there's width calculations going on for each gif preview, the regular modal sizing doesn't work so we need to make an exception.