### PR TITLE
FIX: Modal is not opening from the chat

### DIFF
--- a/javascripts/discourse/initializers/gif-integration.js
+++ b/javascripts/discourse/initializers/gif-integration.js
@@ -38,8 +38,6 @@ export default {
         api.modifyClass("component:chat-composer", {
           pluginId: "discourse-gifs",
 
-          modal: service(),
-
           @action
           showChatGifModal(context) {
             this.modal.show(GifModal, {


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/gif-bug-in-chat/288369/5?u=arkshine

Followup 9607c7afafa6c470dd2ba184d19344524259ddc9.

Opening the GIF modal from the chat results in this error:
![image](https://github.com/discourse/discourse-gifs/assets/360640/5d0c8a52-6df5-485b-bb6f-9e97e1aa6408)

This is because `modal: service()` has been added here:

```js
        api.modifyClass("component:chat-composer", {
          pluginId: "discourse-gifs",

          modal: service(),

          @action
          showChatGifModal(context) {
            this.modal.show(GifModal, {
```
However, `ChatComposer` base [class](https://github.com/discourse/discourse/blob/main/plugins/chat/assets/javascripts/discourse/components/chat-composer.js#L44) already has the service. 
This breaks inheritance with `ChatComposerChannel` [child class](https://github.com/discourse/discourse/blob/main/plugins/chat/assets/javascripts/discourse/components/chat/composer/channel.js), making `this.modal` unavailable when `showChatGifModal` is called.

As a solution, `modal: service(),` is removed.
Result after the fix:

![image](https://github.com/discourse/discourse-gifs/assets/360640/9fdd6318-fb36-49e5-b935-3ef557cf1989)
