### PR TITLE
DEV: add back copy-masonry script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
     "ember-template-lint": "^5.13.0",
     "eslint": "^8.56.0",
     "prettier": "^2.8.8"
+  },
+  "scripts": {
+    "copy-masonry": "cp node_modules/minimasonry/src/minimasonry.js javascripts/discourse/lib/minimasonry.js"
   }
 }


### PR DESCRIPTION
This returns a manifest script that was previously removed by the update-linting script.