### PR TITLE
DEV: rely on modal autofocus

### DIFF
--- a/javascripts/discourse/components/modal/gif.hbs
+++ b/javascripts/discourse/components/modal/gif.hbs
@@ -6,12 +6,7 @@
 >
   <:body>
     <div class="gif-input">
-      <Input
-        {{on "input" this.refresh}}
-        @type="text"
-        name="query"
-        autofocus={{true}}
-      />
+      <Input {{on "input" this.refresh}} @type="text" name="query" />
 
       {{#if this.loading}}
         {{loading-spinner size="small"}}


### PR DESCRIPTION
Every DModal has an automatic behavior where it will attempt to focus the first focusable element, the `autofocus={{true}}` is unnecessary and would also print a warning in the browser console as each behavior fight with each other.