### PR TITLE
DEV: Prevent static mobileView access during initialization

### DIFF
--- a/javascripts/discourse/initializers/gif-integration.js
+++ b/javascripts/discourse/initializers/gif-integration.js
@@ -15,7 +15,7 @@ export default {
             id: "gif_button",
             group: "extras",
             icon: "discourse-gifs-gif",
-            condition: () => !api.container.lookup("service:site").mobileView,
+            condition: () => api.container.lookup("service:site").desktopView,
             action: () => {
               const modal = api.container.lookup("service:modal");
               modal.show(GifModal);


### PR DESCRIPTION
Refactor the `gif-integration` initializer by replacing the static mobile view checks with a dynamic `condition` parameter within `addButton`.