### PR TITLE
DEV: core site setting check for gifs_enabled

### DIFF
--- a/javascripts/discourse/initializers/gif-integration.js
+++ b/javascripts/discourse/initializers/gif-integration.js
@@ -6,6 +6,13 @@ export default {
 
   initialize(container) {
     withPluginApi((api) => {
+      const siteSettings = api.container.lookup("service:site-settings");
+
+      if (siteSettings.enable_gifs) {
+        // return early if core implementation is enabled
+        return;
+      }
+
       api.onToolbarCreate((toolbar) => {
         if (toolbar.context.composerEvents) {
           toolbar.addButton({


### PR DESCRIPTION
Checks for the new core site setting `enable_gifs` and theme component becomes a no-op if it is enabled.