### PR TITLE
loadMore does not work for Klipy categories

### DIFF
--- a/javascripts/discourse/components/modal/gif.gjs
+++ b/javascripts/discourse/components/modal/gif.gjs
@@ -428,7 +428,6 @@ export default class Gif extends Component {
                 @content={{this.categories}}
                 @pick={{this.selectCategory}}
                 @loading={{false}}
-                @loadMore={{this.loadMore}}
               />
             </div>
           </div>


### PR DESCRIPTION
The Klipy categories are not paginated, it's a single call to get all categories. However, there is a `@loadMore={{this.loadMore}}`.

When the "Limit infinite search results" option is not enabled, `loadMore` triggers and Klipy gives an error because there is no `q` parameter.